### PR TITLE
GM9PRO_sprout: Add face unlock support

### DIFF
--- a/lineage_GM9PRO_sprout.mk
+++ b/lineage_GM9PRO_sprout.mk
@@ -27,3 +27,7 @@ PRODUCT_BUILD_PROP_OVERRIDES += \
 BUILD_FINGERPRINT := 'HUAWEI/CLT-L29/HWCLT:8.1.0/HUAWEICLT-L29/128(C432):user/release-keys'
 
 PRODUCT_GMS_CLIENTID_BASE := android-GM
+
+# Adds face unlock if package is available on ROM source
+# Thanks to @Tenshi2112 for telling me about it
+TARGET_SUPPORT_FACE_UNLOCK := true


### PR DESCRIPTION
If package is available on ROM source, the ROM will be compiled with face unlock (Settings > Security).

Thanks to @TeGaX (@Tenshi2112 on Telegram) for telling me about it.