### PR TITLE
Add face unlock and VFOD (Virtual FOD)

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -427,3 +427,8 @@ PRODUCT_PACKAGES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.vendor.qti.config.zram=true \
     ro.vendor.qti.config.zramsize=536870912
+
+# Adds face unlock and VFOD (Virtual FOD). Thanks to @Tenshi2112 for providing me the flags.
+# If you think VFOD is unnecessary and don't want it to take place on your build, add hashtag to the beginning of second flag and it will be ignored.
+TARGET_SUPPORT_FACE_UNLOCK := true
+TARGET_HAS_FOD := true

--- a/lineage_GM9PRO_sprout.mk
+++ b/lineage_GM9PRO_sprout.mk
@@ -27,7 +27,3 @@ PRODUCT_BUILD_PROP_OVERRIDES += \
 BUILD_FINGERPRINT := 'HUAWEI/CLT-L29/HWCLT:8.1.0/HUAWEICLT-L29/128(C432):user/release-keys'
 
 PRODUCT_GMS_CLIENTID_BASE := android-GM
-
-# Adds face unlock if package is available on ROM source
-# Thanks to @Tenshi2112 for telling me about it
-TARGET_SUPPORT_FACE_UNLOCK := true

--- a/lineage_GM9PRO_sprout.mk
+++ b/lineage_GM9PRO_sprout.mk
@@ -27,3 +27,7 @@ PRODUCT_BUILD_PROP_OVERRIDES += \
 BUILD_FINGERPRINT := 'HUAWEI/CLT-L29/HWCLT:8.1.0/HUAWEICLT-L29/128(C432):user/release-keys'
 
 PRODUCT_GMS_CLIENTID_BASE := android-GM
+
+# Adds face unlock if package is available on ROM source
+# Thanks to @Tenshi2112 for telling me about it
+TARGET_SUPPORT_FACE_UNLOCK := true


### PR DESCRIPTION
@TeGaX (@Tenshi2112 on Telegram) warned me regarding the location I added face unlock flag. Now, upon his instructions, I placed it correctly and it should works across all ROMs after this change.

Explaining VFOD (Virtual FOD): ROM thinks and reacts as you have a Fingerprint on Display (FOD) but scans your fingerprint using the hardware itself - For GM 9 Pro, the sensor is located under the rear camera on the case.

This change will also be done for windowzytch/android_device_wileyfox_crackling