### PR TITLE
GM9PRO_sprout: Change location for face unlock

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -427,3 +427,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.vendor.qti.config.zram=true \
     ro.vendor.qti.config.zramsize=536870912
+
+# Face unlock - Credit: @Tenshi2112
+TARGET_SUPPORT_FACE_UNLOCK := true

--- a/lineage_GM9PRO_sprout.mk
+++ b/lineage_GM9PRO_sprout.mk
@@ -28,6 +28,4 @@ BUILD_FINGERPRINT := 'HUAWEI/CLT-L29/HWCLT:8.1.0/HUAWEICLT-L29/128(C432):user/re
 
 PRODUCT_GMS_CLIENTID_BASE := android-GM
 
-# Adds face unlock if package is available on ROM source
-# Thanks to @Tenshi2112 for telling me about it
-TARGET_SUPPORT_FACE_UNLOCK := true
+


### PR DESCRIPTION
This commit was done to move face unlock flag from device's makefile to device.mk.
Thanks to @TeGaX (@Tenshi2112 on Telegram) for warning me regarding that!