### PR TITLE
GM9PRO_sprout: Add face unlock support

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -437,3 +437,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.vendor.qti.config.zram=true \
     ro.vendor.qti.config.zramsize=536870912
+
+# Face unlock - Credit: @Tenshi2112
+TARGET_SUPPORT_FACE_UNLOCK := true


### PR DESCRIPTION
This commit adds face unlock for ROMs having package for that.

Basically PR #1 and PR #3 ( Fix for PR #1 ) but in a single commit and single file change instead.