### PR TITLE
GM9PRO_sprout: Switch to source built vendor.qti.hardware.perf@1.0.so

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -314,7 +314,8 @@ PRODUCT_COPY_FILES += \
 
 # Power
 PRODUCT_PACKAGES += \
-    android.hardware.power-service-qti
+    android.hardware.power-service-qti \
+    vendor.qti.hardware.perf@1.0.vendor
 
 # QCOM
 PRODUCT_COPY_FILES += \

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -822,12 +822,10 @@ vendor/lib/libperfgluelayer.so
 vendor/lib/libqti-perfd.so
 vendor/lib/libqti-util.so
 vendor/lib/libqti-perfd-client.so
-vendor/lib/vendor.qti.hardware.perf@1.0.so
 vendor/lib64/libperfgluelayer.so
 vendor/lib64/libqti-perfd.so
 vendor/lib64/libqti-perfd-client.so
 vendor/lib64/libqti-util.so
-vendor/lib64/vendor.qti.hardware.perf@1.0.so
 
 # Peripheral manager
 vendor/bin/pm-proxy


### PR DESCRIPTION
For some reason, any prebuilt ones from pre-R ROMs no longer work on R
and cause the following error:
  E ANDR-PERF: Unable to link to gPerfHal death notifications!

What's worse, the minimal CPU frequency of both clusters will be locked
at 1113MHz on sdm660.